### PR TITLE
Fix UpdateType by correcting values for 'bell' and 'clipboard'

### DIFF
--- a/asyncvnc.py
+++ b/asyncvnc.py
@@ -433,11 +433,11 @@ class UpdateType(Enum):
     #: Video update.
     VIDEO = 0
 
-    #: Clipboard update.
-    CLIPBOARD = 2
-
     #: Bell update.
-    BELL = 3
+    BELL = 2
+
+    #: Clipboard update.
+    CLIPBOARD = 3
 
 
 @dataclass


### PR DESCRIPTION
According to the  [RFB protocol](https://www.rfc-editor.org/rfc/rfc6143.html#section-7.6), the current values for update types Bell (3) and ServerCutText/Clipboard (2) are mixed up. The correct values should be:

- **2**: Bell
- **3**: ServerCutText (Clipboard)

The current misalignment triggers an issue whenever there's a clipboard update in the X server. This misconfiguration leads to crashes within the library due to encountered exceptions arising from incorrect byte handling.
