### PR TITLE
Fixs the numbers mistake (BELL/CLIPBOARD) and padding mistake in Clipboard.write()

### DIFF
--- a/asyncvnc.py
+++ b/asyncvnc.py
@@ -87,7 +87,7 @@ class Clipboard:
         """
 
         data = text.encode('latin-1')
-        self.writer.write(b'\x06\x00' + len(data).to_bytes(4, 'big') + data)
+        self.writer.write(b'\x06\x00\x00\x00' + len(data).to_bytes(4, 'big') + data)
 
 
 @dataclass
@@ -433,11 +433,11 @@ class UpdateType(Enum):
     #: Video update.
     VIDEO = 0
 
-    #: Clipboard update.
-    CLIPBOARD = 2
-
     #: Bell update.
-    BELL = 3
+    BELL = 2
+
+    #: Clipboard update.
+    CLIPBOARD = 3
 
 
 @dataclass

--- a/tests/test_clipboard.py
+++ b/tests/test_clipboard.py
@@ -5,4 +5,4 @@ from asyncvnc import Clipboard
 def test_write():
     clipboard = Clipboard(writer=BytesIO())
     clipboard.write('hello world!')
-    assert clipboard.writer.getvalue() == b'\x06\x00\x00\x00\x00\x0chello world!'
+    assert clipboard.writer.getvalue() == b'\x06\x00\x00\x00\x00\x00\x00\x0chello world!'


### PR DESCRIPTION
Fixes the numbers mistake (BELL/CLIPBOARD) for server -> client and the padding mistake (Clipboard.write) for client -> server messages.

See: #13

Fixes the test tests/test_clipboard.py for RFC-6143 compliance.